### PR TITLE
Use domain to prevent activating on GitHub

### DIFF
--- a/gitlab-wide.css
+++ b/gitlab-wide.css
@@ -1,6 +1,6 @@
 @namespace url(http://www.w3.org/1999/xhtml);
 
-@-moz-document regexp(".*git(^hub)?.*") {
+@-moz-document domain("gitlab.com") {
     .fixed-width-container,
     .fixed-width-container *,
     .limit-container-width,

--- a/gitlab-wide.css
+++ b/gitlab-wide.css
@@ -1,6 +1,6 @@
 @namespace url(http://www.w3.org/1999/xhtml);
 
-@-moz-document domain(".*git(?!hub).*") {
+@-moz-document regexp(".*git(?!hub).*") {
     .fixed-width-container,
     .fixed-width-container *,
     .limit-container-width,

--- a/gitlab-wide.css
+++ b/gitlab-wide.css
@@ -1,6 +1,6 @@
 @namespace url(http://www.w3.org/1999/xhtml);
 
-@-moz-document domain("gitlab.com") {
+@-moz-document domain(".*git(?!hub).*") {
     .fixed-width-container,
     .fixed-width-container *,
     .limit-container-width,


### PR DESCRIPTION
With default regex the style is active on github.com, this makes it only work on gitlab.com